### PR TITLE
[HPTS Innovation Week]: Onboard Patroni to LockNess and COBS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
 \
     # Clean up all useless packages and some files
     && apt-get purge -y --allow-remove-essential gzip bzip2 util-linux e2fsprogs \
-                libmagic1 bsdmainutils login ncurses-bin libmagic-mgc e2fslibs bsdutils \
+                libmagic1 bsdmainutils login ncurses-bin libmagic-mgc python3-pip e2fslibs bsdutils \
                 exim4-config gnupg-agent dirmngr \
                 git make \
     && apt-get autoremove -y \
@@ -167,8 +167,10 @@ RUN sed -i 's/env python/&3/' /patroni*.py \
     && chmod +s /bin/ping \
     && chown -R postgres:postgres "$PGHOME" /run /etc/haproxy
 
-COPY .github/workflows/install_deps.py .
-RUN python3 install_deps.py
+COPY requirements.txt .
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3 get-pip.py --force-reinstall --break-system-packages
+RUN pip install -r requirements.txt --break-system-packages
 
 USER postgres
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG PGDATA=$PGHOME/data
 ARG LC_ALL=C.UTF-8
 ARG LANG=C.UTF-8
 
-FROM postgres:$PG_MAJOR as builder
+FROM registry.ddbuild.io/images/mirror/postgres:$PG_MAJOR as builder
 
 ARG PGHOME
 ARG PGDATA
@@ -68,7 +68,7 @@ RUN set -ex \
     fi \
 \
     # Clean up all useless packages and some files
-    && apt-get purge -y --allow-remove-essential python3-pip gzip bzip2 util-linux e2fsprogs \
+    && apt-get purge -y --allow-remove-essential gzip bzip2 util-linux e2fsprogs \
                 libmagic1 bsdmainutils login ncurses-bin libmagic-mgc e2fslibs bsdutils \
                 exim4-config gnupg-agent dirmngr \
                 git make \
@@ -166,6 +166,9 @@ RUN sed -i 's/env python/&3/' /patroni*.py \
     && if [ "$COMPRESS" = "true" ]; then chmod u+s /usr/bin/sudo; fi \
     && chmod +s /bin/ping \
     && chown -R postgres:postgres "$PGHOME" /run /etc/haproxy
+
+COPY .github/workflows/install_deps.py .
+RUN python3 install_deps.py
 
 USER postgres
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ ARG LANG
 
 ENV ETCDVERSION=3.3.13 CONFDVERSION=0.16.0
 
+# For LockNess
+ENV OBSERVABILITY=disabled
+
+# For COBS
+
 RUN set -ex \
     && export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
@@ -127,6 +132,11 @@ RUN if [ "$COMPRESS" = "true" ]; then \
         && /bin/busybox sh -c "find $save_dirs -type d -depth -exec rmdir -p {} \; 2> /dev/null"; \
     fi
 
+COPY requirements.txt .
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3 get-pip.py --force-reinstall --break-system-packages
+RUN pip install -r requirements.txt --break-system-packages
+
 FROM scratch
 COPY --from=builder / /
 
@@ -166,11 +176,6 @@ RUN sed -i 's/env python/&3/' /patroni*.py \
     && if [ "$COMPRESS" = "true" ]; then chmod u+s /usr/bin/sudo; fi \
     && chmod +s /bin/ping \
     && chown -R postgres:postgres "$PGHOME" /run /etc/haproxy
-
-COPY requirements.txt .
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN python3 get-pip.py --force-reinstall --break-system-packages
-RUN pip install -r requirements.txt --break-system-packages
 
 USER postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
         environment:
             <<: *haproxy_env
             PATRONI_NAME: patroni1
+            LOCKNESS_PORT: 9111
 
     patroni2:
         image: ${PATRONI_TEST_IMAGE:-patroni}
@@ -73,6 +74,7 @@ services:
         environment:
             <<: *haproxy_env
             PATRONI_NAME: patroni2
+            LOCKNESS_PORT: 9112
 
     patroni3:
         image: ${PATRONI_TEST_IMAGE:-patroni}
@@ -83,3 +85,4 @@ services:
         environment:
             <<: *haproxy_env
             PATRONI_NAME: patroni3
+            LOCKNESS_PORT: 9113

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -130,11 +130,14 @@ def iter_dcs_classes(
 
             try:
                 module = importlib.import_module(mod_name)
+                print("imported module ", module)
                 dcs_module = find_dcs_class_in_module(module)
+                print("class in module ", dcs_module)
                 if dcs_module:
                     yield name, dcs_module
 
-            except ImportError:
+            except ImportError as e:
+                logger.error('Failed to import %s: %s', mod_name, e)
                 logger.log(logging.DEBUG if config is not None else logging.INFO,
                            'Failed to import %s', mod_name)
 
@@ -183,6 +186,7 @@ def get_dcs(config: Union['Config', Dict[str, Any]]) -> 'AbstractDCS':
         # From citus section we only need "group" parameter, but will propagate everything just in case.
         if isinstance(config.get('citus'), dict):
             config[name].update(config['citus'])
+        print("DCS class loaded ", config[name])
         return dcs_class(config[name])
 
     raise PatroniFatalException(
@@ -1029,7 +1033,7 @@ class Cluster(NamedTuple('Cluster',
     def use_slots(self) -> bool:
         """``True`` if cluster is configured to use replication slots."""
         return bool(self.config and (self.config.data.get('postgresql') or {}).get('use_slots', True))
-    
+
     @property
     def wait_for_postmaster_shutdown(self) -> bool:
         return bool(self.config

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import cobs_client
+import os
 from typing import Dict, Any, Union, Optional
+from patroni.dcs import Cluster, ClusterConfig, TimelineHistory, Status, Member, Leader, Failover, SyncState
 
 from patroni.dcs import AbstractDCS
 from patroni.config import Config
@@ -163,11 +165,3 @@ class Cobs(AbstractDCS):
             failsafe = None
 
         return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
-        """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
-
-        :param value: failsafe topology serialized in JSON format.
-
-        :returns: ``True`` if successfully committed to DCS.
-        """
-        logger.info(f"Writing failsafe topology {value}")
-        return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -58,6 +58,11 @@ class Cobs(AbstractDCS):
         with self._ks.read() as snapshot:
             return snapshot.get(key)
 
+    def set_ttl(self, ttl: int) -> None:
+        logger.info(f"Setting TTL to {ttl}")
+        # Implement TTL setting logic here
+        self.set('ttl', str(ttl))
+
     @property
     def ttl(self) -> int:
         # Implement logic to get current TTL

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -95,5 +95,3 @@ class Cobs(AbstractDCS):
         """
         logger.info(f"Writing failsafe topology {value}")
         return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
-        logger.info(f"Writing leader optime {leader_optime}")
-        return self._ks.transact(lambda tx: tx.set(self.leader_optime_path, leader_optime.encode('utf-8')))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -44,7 +44,11 @@ class Cobs():
         :returns: ``True`` if the operation was successful.
         """
         logger.info(f"Setting key {key} with value {value}")
-        return self._ks.transact(lambda tx: tx.set(key, value.encode('utf-8') if isinstance(value, str) else value))
+        try:
+            return self._ks.transact(lambda tx: tx.set(key, value.encode('utf-8') if isinstance(value, str) else value))
+        except Exception as e:
+            logger.error(f"Failed to set key {key} with value {value}: {e}")
+            return False
 
     def get(self, key: str) -> Optional[bytes]:
         """Get the value for a given key from Cobs.
@@ -54,8 +58,12 @@ class Cobs():
         :returns: The value as bytes if the key exists, otherwise ``None``.
         """
         logger.info(f"Getting value for key {key}")
-        with self._ks.read() as snapshot:
-            return snapshot.get(key)
+        try:
+            with self._ks.read() as snapshot:
+                return snapshot.get(key)
+        except Exception as e:
+            logger.error(f"Failed to get value for key {key}: {e}")
+            return None
 
     def set_ttl(self, ttl: int) -> None:
         logger.info(f"Setting TTL to {ttl}")
@@ -73,39 +81,75 @@ class Cobs():
 
     def touch_member(self, member_path: str, value: str) -> bool:
         logger.info(f"Touching member with data {value}")
-        return self._ks.transact(lambda tx: tx.set(self.members_path + member_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.members_path + member_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to touch member with data {value}: {e}")
+            return False
 
     def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
         logger.info(f"Initializing with sysid {sysid}")
-        return self._ks.transact(lambda tx: tx.set(self.initialize_path, sysid.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.initialize_path, sysid.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to initialize with sysid {sysid}: {e}")
+            return False
 
     def cancel_initialization(self) -> bool:
         logger.info("Canceling initialization")
-        return self._ks.transact(lambda tx: tx.delete(self.initialize_path))
+        try:
+            return self._ks.transact(lambda tx: tx.delete(self.initialize_path))
+        except Exception as e:
+            logger.error(f"Failed to cancel initialization: {e}")
+            return False
 
     def set_failover_value(self, value: str, version: Optional[Any] = None) -> bool:
         logger.info(f"Setting failover value {value}")
-        return self._ks.transact(lambda tx: tx.set(self.failover_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.failover_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to set failover value {value}: {e}")
+            return False
 
     def set_config_value(self, value: str, version: Optional[Any] = None) -> bool:
         logger.info(f"Setting config value {value}")
-        return self._ks.transact(lambda tx: tx.set(self.config_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.config_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to set config value {value}: {e}")
+            return False
 
     def set_sync_state_value(self, value: str, version: Optional[Any] = None) -> Union[Any, bool]:
         logger.info(f"Setting sync state value {value}")
-        return self._ks.transact(lambda tx: tx.set(self.sync_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.sync_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to set sync state value {value}: {e}")
+            return False
 
     def delete_sync_state(self, version: Optional[Any] = None) -> bool:
         logger.info("Deleting sync state")
-        return self._ks.transact(lambda tx: tx.delete(self.sync_path))
+        try:
+            return self._ks.transact(lambda tx: tx.delete(self.sync_path))
+        except Exception as e:
+            logger.error(f"Failed to delete sync state: {e}")
+            return False
 
     def set_history_value(self, value: str) -> bool:
         logger.info(f"Setting history value {value}")
-        return self._ks.transact(lambda tx: tx.set(self.history_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.history_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to set history value {value}: {e}")
+            return False
 
     def delete_cluster(self) -> bool:
         logger.info("Deleting cluster")
-        return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
+        try:
+            return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
+        except Exception as e:
+            logger.error(f"Failed to delete cluster: {e}")
+            return False
 
     def write_failsafe(self, value: str) -> bool:
         """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
@@ -115,7 +159,11 @@ class Cobs():
          :returns: ``True`` if successfully committed to DCS.
          """
         logger.info(f"Writing failsafe topology {value}")
-        return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
+        try:
+            return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
+        except Exception as e:
+            logger.error(f"Failed to write failsafe topology {value}: {e}")
+            return False
 
 
     def cluster_loader(self, path: str) -> Cluster:

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -3,6 +3,7 @@ from cobs_client import CobsClient
 from typing import Dict, Any, Union
 
 from patroni.dcs import AbstractDCS
+from patroni.config import Config
 
 logger = logging.getLogger(__name__)
 

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -28,3 +28,12 @@ class Cobs():
     def cancel_initialization(self, init_path: str):
         logger.info(f"Canceling initialization of Cobs with path {init_path}")
         return self._ks.transact(lambda tx: tx.delete(init_path))
+
+    def set(self, key: str, value: Union[str, bytes]):
+        logger.info(f"Setting key {key} with value {value}")
+        return self._ks.transact(lambda tx: tx.set(key, value))
+
+    def get(self, key: str):
+        logger.info(f"Getting value for key {key}")
+        with self._ks.read() as snapshot:
+            return snapshot.get(key)

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -22,6 +22,10 @@ class Cobs():
         """
         logger.info(f"Connecting to Cobs at host.docker.internal:8080")
         self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config?auth=off")
+        try:
+            self._ks.transact(lambda tx: tx.set('ttl', '30'))
+        except Exception as e:
+            logger.error(f"Failed to set TTL: {e}")
 
         # Set default paths
         self.initialize_path = '/service/initialize'
@@ -60,7 +64,7 @@ class Cobs():
         logger.info(f"Getting value for key {key}")
         try:
             with self._ks.read() as snapshot:
-                return snapshot.get(key)
+                return snapshot.get(key).decode('utf-8')
         except Exception as e:
             logger.error(f"Failed to get value for key {key}: {e}")
             return None
@@ -82,7 +86,7 @@ class Cobs():
     def touch_member(self, member_path: str, value: str) -> bool:
         logger.info(f"Touching member with data {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.members_path + member_path, value.encode('utf-8')))
+            return self._ks.transact(lambda tx: tx.set(member_path, value.encode('utf-8')))
         except Exception as e:
             logger.error(f"Failed to touch member with data {value}: {e}")
             return False
@@ -90,7 +94,8 @@ class Cobs():
     def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
         logger.info(f"Initializing with sysid {sysid}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.initialize_path, sysid.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.initialize_path, "true".encode('utf-8')))
+            return True
         except Exception as e:
             logger.error(f"Failed to initialize with sysid {sysid}: {e}")
             return False
@@ -98,7 +103,8 @@ class Cobs():
     def cancel_initialization(self) -> bool:
         logger.info("Canceling initialization")
         try:
-            return self._ks.transact(lambda tx: tx.delete(self.initialize_path))
+            self._ks.transact(lambda tx: tx.delete(self.initialize_path))
+            return True
         except Exception as e:
             logger.error(f"Failed to cancel initialization: {e}")
             return False
@@ -106,7 +112,8 @@ class Cobs():
     def set_failover_value(self, value: str, version: Optional[Any] = None) -> bool:
         logger.info(f"Setting failover value {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.failover_path, value.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.failover_path, value.encode('utf-8')))
+            return True
         except Exception as e:
             logger.error(f"Failed to set failover value {value}: {e}")
             return False
@@ -114,7 +121,8 @@ class Cobs():
     def set_config_value(self, value: str, version: Optional[Any] = None) -> bool:
         logger.info(f"Setting config value {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.config_path, value.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.config_path, value.encode('utf-8')))
+            return True
         except Exception as e:
             logger.error(f"Failed to set config value {value}: {e}")
             return False
@@ -122,7 +130,8 @@ class Cobs():
     def set_sync_state_value(self, value: str, version: Optional[Any] = None) -> Union[Any, bool]:
         logger.info(f"Setting sync state value {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.sync_path, value.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.sync_path, value.encode('utf-8')))
+            return value
         except Exception as e:
             logger.error(f"Failed to set sync state value {value}: {e}")
             return False
@@ -130,7 +139,8 @@ class Cobs():
     def delete_sync_state(self, version: Optional[Any] = None) -> bool:
         logger.info("Deleting sync state")
         try:
-            return self._ks.transact(lambda tx: tx.delete(self.sync_path))
+            self._ks.transact(lambda tx: tx.delete(self.sync_path))
+            return True
         except Exception as e:
             logger.error(f"Failed to delete sync state: {e}")
             return False
@@ -138,7 +148,8 @@ class Cobs():
     def set_history_value(self, value: str) -> bool:
         logger.info(f"Setting history value {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.history_path, value.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.history_path, value.encode('utf-8')))
+            return True
         except Exception as e:
             logger.error(f"Failed to set history value {value}: {e}")
             return False
@@ -146,7 +157,8 @@ class Cobs():
     def delete_cluster(self) -> bool:
         logger.info("Deleting cluster")
         try:
-            return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
+            self._ks.transact(lambda tx: tx.delete(self.client_path('')))
+            return True
         except Exception as e:
             logger.error(f"Failed to delete cluster: {e}")
             return False
@@ -160,10 +172,28 @@ class Cobs():
          """
         logger.info(f"Writing failsafe topology {value}")
         try:
-            return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
+            self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
+            return True
         except Exception as e:
             logger.error(f"Failed to write failsafe topology {value}: {e}")
             return False
+
+
+    def get_members(self) -> Dict[str, str]:
+        logger.info("Getting members")
+
+        # TODO: cobs_client does not support range reads right now so we have to
+        # hardcode the possible member names here
+        member_names = ["patroni1", "patroni2", "patroni3"]
+        node_data = {}
+        try:
+            for member in member_names:
+                node_data[member] = self.get(self.members_path + member)
+
+            return node_data
+        except Exception as e:
+            logger.error(f"Failed to get members: {e}")
+            return {}
 
 
     def cluster_loader(self, path: str) -> Cluster:
@@ -173,51 +203,57 @@ class Cobs():
 
         :returns: :class:`Cluster` instance.
         """
-        nodes = {node['key'][len(path):]: node
-                 for node in self._ks.read(path)
-                 if node['key'].startswith(path)}
-
-        # get initialize flag
-        initialize = self.get(self.initialize_path)
-        initialize = initialize and initialize.decode('utf-8')
-
-        # get global dynamic configuration
-        config = self.get(self.config_path)
-        config = config and ClusterConfig.from_node(0, config.decode('utf-8'))
-
-        # get timeline history
-        history = self.get(self.history_path)
-        history = history and TimelineHistory.from_node(0, history.decode('utf-8'))
-
-        # get last known leader lsn and slots
-        status = self.get(self.status_path) or self.get(self.leader_optime_path)
-        status = Status.from_node(status and status.decode('utf-8'))
-
-        # get list of members
-        members = [Member.from_node(0, os.path.basename(node['key']), None, node['value'].decode('utf-8'))
-                   for node in nodes.values() if node['key'].startswith(self.members_path) and node['key'].count('/') == 1]
-
-        # get leader
-        leader = self.get(self.leader_path)
-        if leader:
-            member = Member(-1, leader.decode('utf-8'), None, {})
-            member = ([m for m in members if m.name == leader.decode('utf-8')] or [member])[0]
-            leader = Leader(0, None, member)
-
-        # failover key
-        failover = self.get(self.failover_path)
-        if failover:
-            failover = Failover.from_node(0, failover.decode('utf-8'))
-
-        # get synchronization state
-        sync = self.get(self.sync_path)
-        sync = SyncState.from_node(0, sync and sync.decode('utf-8'))
-
-        # get failsafe topology
-        failsafe = self.get(self.failsafe_path)
         try:
-            failsafe = json.loads(failsafe.decode('utf-8')) if failsafe else None
-        except Exception:
-            failsafe = None
+            nodes = self.get_members()
 
-        return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
+            logger.info(f"NODES: {nodes}")
+
+            # get initialize flag
+            initialize = self.get(self.initialize_path)
+            initialize = initialize and initialize.decode('utf-8')
+
+            # get global dynamic configuration
+            config = self.get(self.config_path)
+            config = config and ClusterConfig.from_node(0, config.decode('utf-8'))
+
+            # get timeline history
+            history = self.get(self.history_path)
+            history = history and TimelineHistory.from_node(0, history.decode('utf-8'))
+
+            # get last known leader lsn and slots
+            status = self.get(self.status_path) or self.get(self.leader_optime_path)
+            status = Status.from_node(status and status.decode('utf-8'))
+
+            # get list of members
+            if nodes and nodes != {}:
+                members = [Member.from_node(0, name, data.decode('utf-8')) for name, data in nodes.items()]
+
+                # get leader
+                leader = self.get(self.leader_path)
+                if leader:
+                    member = Member(-1, leader.decode('utf-8'), None, {})
+                    member = ([m for m in members if m.name == leader.decode('utf-8')] or [member])[0]
+                    leader = Leader(0, None, member)
+
+                # failover key
+                failover = self.get(self.failover_path)
+                if failover:
+                    failover = Failover.from_node(0, failover.decode('utf-8'))
+
+                # get synchronization state
+                sync = self.get(self.sync_path)
+                sync = SyncState.from_node(0, sync and sync.decode('utf-8'))
+
+                # get failsafe topology
+                failsafe = self.get(self.failsafe_path)
+                try:
+                    failsafe = json.loads(failsafe.decode('utf-8')) if failsafe else None
+                except Exception:
+                    failsafe = None
+
+                return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
+            else:
+                return Cluster.empty()
+        except Exception as e:
+            logger.error(f"Failed to load cluster from path {path}: {e}")
+            return Cluster.empty()

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -36,7 +36,27 @@ class Cobs(AbstractDCS):
         self.sync_path = '/service/sync'
         self.failsafe_path = '/service/failsafe'
 
-    def set_ttl(self, ttl: int) -> Optional[bool]:
+    def set(self, key: str, value: Union[str, bytes]) -> bool:
+        """Set a value for a given key in Cobs.
+
+        :param key: The key to set the value for.
+        :param value: The value to set, either as a string or bytes.
+
+        :returns: ``True`` if the operation was successful.
+        """
+        logger.info(f"Setting key {key} with value {value}")
+        return self._ks.transact(lambda tx: tx.set(key, value.encode('utf-8') if isinstance(value, str) else value))
+
+    def get(self, key: str) -> Optional[bytes]:
+        """Get the value for a given key from Cobs.
+
+        :param key: The key to retrieve the value for.
+
+        :returns: The value as bytes if the key exists, otherwise ``None``.
+        """
+        logger.info(f"Getting value for key {key}")
+        with self._ks.read() as snapshot:
+            return snapshot.get(key)
         logger.info(f"Setting TTL to {ttl}")
         # Implement TTL setting logic here
         return True

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -7,18 +7,24 @@ from patroni.config import Config
 
 logger = logging.getLogger(__name__)
 
-class CobsDCS():
+class Cobs():
     """
     A class to manage distributed coordination using the Cobs service.
     """
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self) -> None:
         """
         Initialize the CobsDCS client with the given configuration.
 
         :param config: A dictionary containing configuration parameters.
         """
-        self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config")
+        logger.info(f"Connecting to Cobs at host.docker.internal:8080")
+        self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config?auth=off")
 
-    def initialize(self, create_new: bool = True, sysid: str = ""):
-        return self.retry(self._client.put, self.initialize_path, sysid, create_revision='0' if create_new else None)
+    def initialize(self, init_path: str):
+        logger.info(f"Initializing Cobs with path {init_path}")
+        return self._ks.transact(lambda tx: tx.set(init_path, bytes("true", 'utf-8')))
+
+    def cancel_initialization(self, init_path: str):
+        logger.info(f"Canceling initialization of Cobs with path {init_path}")
+        return self._ks.transact(lambda tx: tx.delete(init_path))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -1,9 +1,9 @@
 import json
 import logging
 import cobs_client
-from typing import Dict, Any, Union
+from typing import Dict, Any, Union, Optional
 
-# from patroni.dcs import AbstractDCS
+from patroni.dcs import AbstractDCS
 from patroni.config import Config
 
 logger = logging.getLogger(__name__)

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import cobs_client
 from typing import Dict, Any, Union
@@ -7,12 +8,13 @@ from patroni.config import Config
 
 logger = logging.getLogger(__name__)
 
-class Cobs():
+class Cobs(AbstractDCS):
     """
     A class to manage distributed coordination using the Cobs service.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, config: Dict[str, Any]) -> None:
+        super().__init__(config)
         """
         Initialize the CobsDCS client with the given configuration.
 
@@ -21,19 +23,56 @@ class Cobs():
         logger.info(f"Connecting to Cobs at host.docker.internal:8080")
         self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config?auth=off")
 
-    def initialize(self, init_path: str):
-        logger.info(f"Initializing Cobs with path {init_path}")
-        return self._ks.transact(lambda tx: tx.set(init_path, bytes("true", 'utf-8')))
+    def set_ttl(self, ttl: int) -> Optional[bool]:
+        logger.info(f"Setting TTL to {ttl}")
+        # Implement TTL setting logic here
+        return True
 
-    def cancel_initialization(self, init_path: str):
-        logger.info(f"Canceling initialization of Cobs with path {init_path}")
-        return self._ks.transact(lambda tx: tx.delete(init_path))
+    @property
+    def ttl(self) -> int:
+        # Implement logic to get current TTL
+        return 30
 
-    def set(self, key: str, value: Union[str, bytes]):
-        logger.info(f"Setting key {key} with value {value}")
-        return self._ks.transact(lambda tx: tx.set(key, value))
+    def set_retry_timeout(self, retry_timeout: int) -> None:
+        logger.info(f"Setting retry timeout to {retry_timeout}")
+        # Implement retry timeout setting logic here
 
-    def get(self, key: str):
-        logger.info(f"Getting value for key {key}")
-        with self._ks.read() as snapshot:
-            return snapshot.get(key)
+    def touch_member(self, data: Dict[str, Any]) -> bool:
+        logger.info(f"Touching member with data {data}")
+        return self._ks.transact(lambda tx: tx.set(self.member_path, json.dumps(data).encode('utf-8')))
+
+    def take_leader(self) -> bool:
+        logger.info("Taking leader")
+        return self._ks.transact(lambda tx: tx.set(self.leader_path, self._name.encode('utf-8')))
+
+    def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
+        logger.info(f"Initializing with sysid {sysid}")
+        return self._ks.transact(lambda tx: tx.set(self.initialize_path, sysid.encode('utf-8')))
+
+    def cancel_initialization(self) -> bool:
+        logger.info("Canceling initialization")
+        return self._ks.transact(lambda tx: tx.delete(self.initialize_path))
+
+    def set_failover_value(self, value: str, version: Optional[Any] = None) -> bool:
+        logger.info(f"Setting failover value {value}")
+        return self._ks.transact(lambda tx: tx.set(self.failover_path, value.encode('utf-8')))
+
+    def set_config_value(self, value: str, version: Optional[Any] = None) -> bool:
+        logger.info(f"Setting config value {value}")
+        return self._ks.transact(lambda tx: tx.set(self.config_path, value.encode('utf-8')))
+
+    def set_sync_state_value(self, value: str, version: Optional[Any] = None) -> Union[Any, bool]:
+        logger.info(f"Setting sync state value {value}")
+        return self._ks.transact(lambda tx: tx.set(self.sync_path, value.encode('utf-8')))
+
+    def delete_sync_state(self, version: Optional[Any] = None) -> bool:
+        logger.info("Deleting sync state")
+        return self._ks.transact(lambda tx: tx.delete(self.sync_path))
+
+    def set_history_value(self, value: str) -> bool:
+        logger.info(f"Setting history value {value}")
+        return self._ks.transact(lambda tx: tx.set(self.history_path, value.encode('utf-8')))
+
+    def delete_cluster(self) -> bool:
+        logger.info("Deleting cluster")
+        return self._ks.transact(lambda tx: tx.delete(self.client_path('')))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -86,6 +86,14 @@ class Cobs(AbstractDCS):
         logger.info("Deleting cluster")
         return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
 
-    def write_leader_optime(self, leader_optime: str) -> bool:
+    def _write_failsafe(self, value: str) -> bool:
+        """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
+
+        :param value: failsafe topology serialized in JSON format.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
+        logger.info(f"Writing failsafe topology {value}")
+        return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
         logger.info(f"Writing leader optime {leader_optime}")
         return self._ks.transact(lambda tx: tx.set(self.leader_optime_path, leader_optime.encode('utf-8')))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -1,13 +1,13 @@
 import logging
-from cobs_client import CobsClient
+import cobs_client
 from typing import Dict, Any, Union
 
-from patroni.dcs import AbstractDCS
+# from patroni.dcs import AbstractDCS
 from patroni.config import Config
 
 logger = logging.getLogger(__name__)
 
-class CobsDCS(AbstractDCS):
+class CobsDCS():
     """
     A class to manage distributed coordination using the Cobs service.
     """
@@ -18,25 +18,7 @@ class CobsDCS(AbstractDCS):
 
         :param config: A dictionary containing configuration parameters.
         """
-        super().__init__(config)
-        self.client = CobsClient(config['host'], config['port'])
-        self._base_path = config.get('base_path', '/')
-        logger.info(f"Connected to Cobs at {config['host']}:{config['port']}")
+        self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config")
 
-    def client_path(self, path: str) -> str:
-        """
-        Construct the full client path.
-
-        :param path: The path to append to the base path.
-        :return: The full client path.
-        """
-        return f"{self._base_path}/{path}"
-
-    def reload_config(self, config: Union['Config', Dict[str, Any]]) -> None:
-        """
-        Reload the configuration.
-
-        :param config: The new configuration to apply.
-        """
-        self.client.reload_config(config)
-        logger.info("Configuration reloaded.")
+    def initialize(self, create_new: bool = True, sysid: str = ""):
+        return self.retry(self._client.put, self.initialize_path, sysid, create_revision='0' if create_new else None)

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -54,10 +54,6 @@ class Cobs(AbstractDCS):
         logger.info(f"Touching member with data {data}")
         return self._ks.transact(lambda tx: tx.set(self.member_path, json.dumps(data).encode('utf-8')))
 
-    def take_leader(self) -> bool:
-        logger.info("Taking leader")
-        return self._ks.transact(lambda tx: tx.set(self.leader_path, self._name.encode('utf-8')))
-
     def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
         logger.info(f"Initializing with sysid {sysid}")
         return self._ks.transact(lambda tx: tx.set(self.initialize_path, sysid.encode('utf-8')))
@@ -89,3 +85,7 @@ class Cobs(AbstractDCS):
     def delete_cluster(self) -> bool:
         logger.info("Deleting cluster")
         return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
+
+    def write_leader_optime(self, leader_optime: str) -> bool:
+        logger.info(f"Writing leader optime {leader_optime}")
+        return self._ks.transact(lambda tx: tx.set(self.leader_optime_path, leader_optime.encode('utf-8')))

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -1,0 +1,41 @@
+import logging
+from cobs_client import CobsClient
+from typing import Dict, Any, Union
+
+from patroni.dcs import AbstractDCS
+
+logger = logging.getLogger(__name__)
+
+class CobsDCS(AbstractDCS):
+    """
+    A class to manage distributed coordination using the Cobs service.
+    """
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        """
+        Initialize the CobsDCS client with the given configuration.
+
+        :param config: A dictionary containing configuration parameters.
+        """
+        super().__init__(config)
+        self.client = CobsClient(config['host'], config['port'])
+        self._base_path = config.get('base_path', '/')
+        logger.info(f"Connected to Cobs at {config['host']}:{config['port']}")
+
+    def client_path(self, path: str) -> str:
+        """
+        Construct the full client path.
+
+        :param path: The path to append to the base path.
+        :return: The full client path.
+        """
+        return f"{self._base_path}/{path}"
+
+    def reload_config(self, config: Union['Config', Dict[str, Any]]) -> None:
+        """
+        Reload the configuration.
+
+        :param config: The new configuration to apply.
+        """
+        self.client.reload_config(config)
+        logger.info("Configuration reloaded.")

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -57,9 +57,6 @@ class Cobs(AbstractDCS):
         logger.info(f"Getting value for key {key}")
         with self._ks.read() as snapshot:
             return snapshot.get(key)
-        logger.info(f"Setting TTL to {ttl}")
-        # Implement TTL setting logic here
-        return True
 
     @property
     def ttl(self) -> int:

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -5,18 +5,16 @@ import os
 from typing import Dict, Any, Union, Optional
 from patroni.dcs import Cluster, ClusterConfig, TimelineHistory, Status, Member, Leader, Failover, SyncState
 
-from patroni.dcs import AbstractDCS
 from patroni.config import Config
 
 logger = logging.getLogger(__name__)
 
-class Cobs(AbstractDCS):
+class Cobs():
     """
     A class to manage distributed coordination using the Cobs service.
     """
 
-    def __init__(self, config: Dict[str, Any]) -> None:
-        super().__init__(config)
+    def __init__(self) -> None:
         """
         Initialize the CobsDCS client with the given configuration.
 
@@ -29,7 +27,6 @@ class Cobs(AbstractDCS):
         self.initialize_path = '/service/initialize'
         self.config_path = '/service/config'
         self.members_path = '/service/members/'
-        self.member_path = f'/service/members/{self._name}'
         self.leader_path = '/service/leader'
         self.failover_path = '/service/failover'
         self.history_path = '/service/history'
@@ -74,9 +71,9 @@ class Cobs(AbstractDCS):
         logger.info(f"Setting retry timeout to {retry_timeout}")
         # Implement retry timeout setting logic here
 
-    def touch_member(self, data: Dict[str, Any]) -> bool:
-        logger.info(f"Touching member with data {data}")
-        return self._ks.transact(lambda tx: tx.set(self.member_path, json.dumps(data).encode('utf-8')))
+    def touch_member(self, member_path: str, value: str) -> bool:
+        logger.info(f"Touching member with data {value}")
+        return self._ks.transact(lambda tx: tx.set(self.members_path + member_path, value.encode('utf-8')))
 
     def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
         logger.info(f"Initializing with sysid {sysid}")
@@ -110,7 +107,18 @@ class Cobs(AbstractDCS):
         logger.info("Deleting cluster")
         return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
 
-    def _cluster_loader(self, path: str) -> Cluster:
+    def write_failsafe(self, value: str) -> bool:
+        """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
+
+         :param value: failsafe topology serialized in JSON format.
+
+         :returns: ``True`` if successfully committed to DCS.
+         """
+        logger.info(f"Writing failsafe topology {value}")
+        return self._ks.transact(lambda tx: tx.set(self.failsafe_path, value.encode('utf-8')))
+
+
+    def cluster_loader(self, path: str) -> Cluster:
         """Load and build the :class:`Cluster` object from Cobs, which represents a single Patroni or Citus cluster.
 
         :param path: the path in Cobs where to load Cluster(s) from.

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -108,7 +108,61 @@ class Cobs(AbstractDCS):
         logger.info("Deleting cluster")
         return self._ks.transact(lambda tx: tx.delete(self.client_path('')))
 
-    def _write_failsafe(self, value: str) -> bool:
+    def _cluster_loader(self, path: str) -> Cluster:
+        """Load and build the :class:`Cluster` object from Cobs, which represents a single Patroni or Citus cluster.
+
+        :param path: the path in Cobs where to load Cluster(s) from.
+
+        :returns: :class:`Cluster` instance.
+        """
+        nodes = {node['key'][len(path):]: node
+                 for node in self._ks.read(path)
+                 if node['key'].startswith(path)}
+
+        # get initialize flag
+        initialize = self.get(self.initialize_path)
+        initialize = initialize and initialize.decode('utf-8')
+
+        # get global dynamic configuration
+        config = self.get(self.config_path)
+        config = config and ClusterConfig.from_node(0, config.decode('utf-8'))
+
+        # get timeline history
+        history = self.get(self.history_path)
+        history = history and TimelineHistory.from_node(0, history.decode('utf-8'))
+
+        # get last known leader lsn and slots
+        status = self.get(self.status_path) or self.get(self.leader_optime_path)
+        status = Status.from_node(status and status.decode('utf-8'))
+
+        # get list of members
+        members = [Member.from_node(0, os.path.basename(node['key']), None, node['value'].decode('utf-8'))
+                   for node in nodes.values() if node['key'].startswith(self.members_path) and node['key'].count('/') == 1]
+
+        # get leader
+        leader = self.get(self.leader_path)
+        if leader:
+            member = Member(-1, leader.decode('utf-8'), None, {})
+            member = ([m for m in members if m.name == leader.decode('utf-8')] or [member])[0]
+            leader = Leader(0, None, member)
+
+        # failover key
+        failover = self.get(self.failover_path)
+        if failover:
+            failover = Failover.from_node(0, failover.decode('utf-8'))
+
+        # get synchronization state
+        sync = self.get(self.sync_path)
+        sync = SyncState.from_node(0, sync and sync.decode('utf-8'))
+
+        # get failsafe topology
+        failsafe = self.get(self.failsafe_path)
+        try:
+            failsafe = json.loads(failsafe.decode('utf-8')) if failsafe else None
+        except Exception:
+            failsafe = None
+
+        return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
         """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
 
         :param value: failsafe topology serialized in JSON format.

--- a/patroni/dcs/cobs.py
+++ b/patroni/dcs/cobs.py
@@ -23,6 +23,19 @@ class Cobs(AbstractDCS):
         logger.info(f"Connecting to Cobs at host.docker.internal:8080")
         self._ks = cobs_client.sync.open("cobs://host.docker.internal:8080/patroni_config?auth=off")
 
+        # Set default paths
+        self.initialize_path = '/service/initialize'
+        self.config_path = '/service/config'
+        self.members_path = '/service/members/'
+        self.member_path = f'/service/members/{self._name}'
+        self.leader_path = '/service/leader'
+        self.failover_path = '/service/failover'
+        self.history_path = '/service/history'
+        self.status_path = '/service/status'
+        self.leader_optime_path = '/service/optime/leader'
+        self.sync_path = '/service/sync'
+        self.failsafe_path = '/service/failsafe'
+
     def set_ttl(self, ttl: int) -> Optional[bool]:
         logger.info(f"Setting TTL to {ttl}")
         # Implement TTL setting logic here

--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -10,6 +10,7 @@ import socket
 import time
 
 from collections import defaultdict
+from lockness import SyncClient, Heartbeats, LockStatus, LockNessTimeoutError
 from copy import deepcopy
 from dns.exception import DNSException
 from dns import resolver
@@ -41,6 +42,27 @@ class EtcdError(DCSError):
 
 
 _AddrInfo = Tuple[socket.AddressFamily, socket.SocketKind, int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]
+
+
+class LockNess:
+    def __init__(self, config: Dict[str, Any]) -> None:
+        connect_string = config.get('connect_string', 'localhost:9111')
+        self.client = SyncClient.connect(connect_string, heartbeats=Heartbeats.auto(20))
+
+    def acquire_lock(self, target: str, owner: str) -> bool:
+        lock_id = self.client.request_lock(targets=[target], owner=owner, domain="postgres")
+        states = self.client.stream_lock_states(lock_id)
+
+        lock_state = None
+        while lock_state is None or lock_state.status != LockStatus.Acquired:
+            try:
+                lock_state = states.recv(timeout_ms=1000)
+            except LockNessTimeoutError:
+                print("Waiting for lock...")
+
+            print(f"Lock state: {lock_state=}")
+            if lock_state.status == LockStatus.Released:
+                raise RuntimeError("Lock was released before acquired")
 
 
 class DnsCachingResolver(Thread):

--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -541,6 +541,7 @@ class AbstractEtcd(AbstractDCS):
 
     def _run_and_handle_exceptions(self, method: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         retry = kwargs.pop('retry', self.retry)
+        print("retry fn: ", retry)
         try:
             return retry(method, *args, **kwargs) if retry else method(*args, **kwargs)
         except (RetryFailedError, etcd.EtcdConnectionFailed) as e:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -63,24 +63,48 @@ class Etcd3Exception(etcd.EtcdException):
 
 class LockNess:
     def __init__(self, config: Dict[str, Any]) -> None:
-        connect_string = config.get('connect_string', 'localhost:9111')
-        self.client = SyncClient.connect(connect_string, heartbeats=Heartbeats.auto(20))
+        connect_string = config.get('connect_string', 'host.docker.internal')
+        logger.info(f"Connecting to LockNess at {connect_string}")
+        self.client = SyncClient.connect(connect_string, port=9111,
+                                         heartbeats=Heartbeats.manual(),
+                                         auth_n=False)
+        self._lock_id = None
 
-    def acquire_lock(self, target: str, owner: str) -> bool:
-        lock_id = self.client.request_lock(targets=[target], owner=owner, domain="postgres")
+    def acquire_lock(self, target: str, owner: str, ttl: int) -> bool:
+        logger.info(f"Acquiring lock for {target} with owner {owner} and ttl {ttl}")
+        lock_id = self.client.request_lock(targets=[target], owner=owner,
+                                           domain="postgres", ttl=ttl)
+        logger.info(f"LOCK ID: {lock_id}")
+        print(f"LOCK ID: ", lock_id)
         states = self.client.stream_lock_states(lock_id)
+
+        self._lock_id = lock_id
 
         lock_state = None
         while lock_state is None or lock_state.status != LockStatus.Acquired:
             try:
                 lock_state = states.recv(timeout_ms=1000)
+                if lock_state is not None and lock_state.status == LockStatus.Acquired:
+                    return True
+
+                return False
             except LockNessTimeoutError:
-                print("Waiting for lock...")
+                logger.info("Waiting for lock...")
 
-            print(f"Lock state: {lock_state=}")
-            if lock_state.status == LockStatus.Released:
-                raise RuntimeError("Lock was released before acquired")
+            logger.info(f"Lock state: {lock_state=}")
 
+        return False
+
+    def heartbeat(self) -> str | None:
+        if self._lock_id is None:
+            return None
+
+        try:
+            self.client.send_heartbeat(self._lock_id)
+        except Exception as e:
+            logger.exception(f"Error sending heartbeat: {e}")
+
+        return self._lock_id
 
 class Etcd3ClientError(Etcd3Exception):
 
@@ -698,6 +722,7 @@ class Etcd3(AbstractEtcd):
         self.__do_not_watch = False
         self._lease = None
         self._last_lease_refresh = 0
+        # self.lockness = LockNess(config)
 
         self._client.configure(self)
         if not self._ctl:
@@ -731,7 +756,8 @@ class Etcd3(AbstractEtcd):
 
         ret = not self._lease
         if ret:
-            self._lease = self._client.lease_grant(self._ttl, retry=retry)
+            # self._lease = self._client.lease_grant(self._ttl, retry=retry)
+            self._lease = self.lockness.heartbeat()
 
         self._last_lease_refresh = time.time()
         return ret
@@ -867,8 +893,10 @@ class Etcd3(AbstractEtcd):
             kwargs['retry'] = retry
             return retry(*args, **kwargs)
 
+        logger.info("attempt to acquire leader")
         try:
             return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
+            # return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
         except LeaseNotFound:
             logger.error('Our lease disappeared from Etcd. Will try to get a new one and retry attempt')
             self._lease = None
@@ -879,6 +907,7 @@ class Etcd3(AbstractEtcd):
             retry.ensure_deadline(1, Etcd3Error('_do_attempt_to_acquire_leader timeout'))
 
             return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
+            # return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
 
     @catch_return_false_exception
     def attempt_to_acquire_leader(self) -> bool:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -10,7 +10,6 @@ import time
 import urllib3
 
 from collections import defaultdict
-from lockness import SyncClient, Heartbeats, LockStatus, LockNessTimeoutError
 from enum import IntEnum
 from urllib3.exceptions import ReadTimeoutError, ProtocolError
 from threading import Condition, Lock, Thread
@@ -18,6 +17,8 @@ from typing import Any, Callable, Collection, Dict, Iterator, List, Optional, Tu
 
 from . import ClusterConfig, Cluster, Failover, Leader, Member, Status, SyncState, \
     TimelineHistory, catch_return_false_exception, citus_group_re
+from .lockness import LockNess
+from .cobs import Cobs
 from .etcd import AbstractEtcdClientWithFailover, AbstractEtcd, catch_etcd_errors, DnsCachingResolver, Retry
 from ..exceptions import DCSError, PatroniException
 from ..utils import deep_compare, enable_keepalive, iter_response_objects, RetryFailedError, USER_AGENT
@@ -60,75 +61,6 @@ GRPCcodeToText: Dict[int, str] = {v: k for k, v in GRPCCode.__dict__['_member_ma
 class Etcd3Exception(etcd.EtcdException):
     pass
 
-
-class LockNess:
-    """
-    A class to manage distributed locks using the LockNess service.
-
-    This class provides methods to acquire locks and send heartbeats to maintain them.
-    It uses a SyncClient to connect to the LockNess service.
-    """
-    def __init__(self, config: Dict[str, Any]) -> None:
-        """
-        Initialize the LockNess client with the given configuration.
-
-        :param config: A dictionary containing configuration parameters.
-        """
-        connect_string = config.get('connect_string', 'host.docker.internal')
-        logger.info(f"Connecting to LockNess at {connect_string}")
-        self.client = SyncClient.connect(connect_string, port=9111,
-                                         heartbeats=Heartbeats.manual(),
-                                         auth_n=False)
-        self._lock_id = None
-
-    def acquire_lock(self, target: str, owner: str, ttl: int) -> bool:
-        """
-        Attempt to acquire a lock for a specified target.
-
-        :param target: The target resource to lock.
-        :param owner: The owner of the lock.
-        :param ttl: Time-to-live for the lock in seconds.
-        :return: True if the lock is acquired, False otherwise.
-        """
-        logger.info(f"Acquiring lock for {target} with owner {owner} and ttl {ttl}")
-        lock_id = self.client.request_lock(targets=[target], owner=owner,
-                                           domain="postgres", ttl=ttl)
-        logger.info(f"LOCK ID: {lock_id}")
-        print(f"LOCK ID: ", lock_id)
-        states = self.client.stream_lock_states(lock_id)
-
-        self._lock_id = lock_id
-
-        lock_state = None
-        while lock_state is None or lock_state.status != LockStatus.Acquired:
-            try:
-                lock_state = states.recv(timeout_ms=1000)
-                if lock_state is not None and lock_state.status == LockStatus.Acquired:
-                    return True
-
-                return False
-            except LockNessTimeoutError:
-                logger.info("Waiting for lock...")
-
-            logger.info(f"Lock state: {lock_state=}")
-
-        return False
-
-    def heartbeat(self) -> str | None:
-        """
-        Send a heartbeat to maintain the lock.
-
-        :return: The lock ID if the heartbeat is successful, None otherwise.
-        """
-        if self._lock_id is None:
-            return None
-
-        try:
-            self.client.send_heartbeat(self._lock_id)
-        except Exception as e:
-            logger.exception(f"Error sending heartbeat: {e}")
-
-        return self._lock_id
 
 class Etcd3ClientError(Etcd3Exception):
 
@@ -746,12 +678,13 @@ class Etcd3(AbstractEtcd):
         self.__do_not_watch = False
         self._lease = None
         self._last_lease_refresh = 0
-        # self.lockness = LockNess(config)
+        self.lockness = LockNess(config, self._ttl)
+        self.cobs = Cobs()
 
         self._client.configure(self)
         if not self._ctl:
             self._client.start_watcher()
-            self.create_lease()
+            # self.create_lease()
 
     @property
     def _client(self) -> PatroniEtcd3Client:
@@ -780,7 +713,7 @@ class Etcd3(AbstractEtcd):
 
         ret = not self._lease
         if ret:
-            # self._lease = self._client.lease_grant(self._ttl, retry=retry)
+            #self._lease = self._client.lease_grant(self._ttl, retry=retry)
             self._lease = self.lockness.heartbeat()
 
         self._last_lease_refresh = time.time()
@@ -919,8 +852,8 @@ class Etcd3(AbstractEtcd):
 
         logger.info("attempt to acquire leader")
         try:
-            return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
-            # return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
+            # return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
+            return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
         except LeaseNotFound:
             logger.error('Our lease disappeared from Etcd. Will try to get a new one and retry attempt')
             self._lease = None
@@ -930,8 +863,8 @@ class Etcd3(AbstractEtcd):
 
             retry.ensure_deadline(1, Etcd3Error('_do_attempt_to_acquire_leader timeout'))
 
-            return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
-            # return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
+            # return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
+            return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
 
     @catch_return_false_exception
     def attempt_to_acquire_leader(self) -> bool:
@@ -978,35 +911,38 @@ class Etcd3(AbstractEtcd):
             kwargs['retry'] = retry
             return retry(*args, **kwargs)
 
-        self._run_and_handle_exceptions(self._do_refresh_lease, True, retry=_retry)
+        # self._run_and_handle_exceptions(self._do_refresh_lease, True, retry=_retry)
 
-        if self._lease and leader.session != self._lease:
-            retry.ensure_deadline(1, Etcd3Error('update_leader timeout'))
+        if self._lease and self._lease != leader.session:
+            return bool(self.attempt_to_acquire_leader())
 
-            fields = {'key': base64_encode(self.leader_path), 'value': base64_encode(self._name), 'lease': self._lease}
+            # fields = {'key': base64_encode(self.leader_path), 'value': base64_encode(self._name), 'lease': self._lease}
             # First we try to update lease on existing leader key "hoping" that we still owning it
-            compare1 = {'key': fields['key'], 'target': 'VALUE', 'value': fields['value']}
-            request_put = {'request_put': fields}
+            # compare1 = {'key': fields['key'], 'target': 'VALUE', 'value': fields['value']}
+            # request_put = {'request_put': fields}
             # If the first comparison failed we will try to create the new leader key in a transaction
-            compare2 = {'key': fields['key'], 'target': 'CREATE', 'create_revision': '0'}
-            request_txn = {'request_txn': {'compare': [compare2], 'success': [request_put]}}
-            ret = self._run_and_handle_exceptions(self._client.txn, compare1, request_put, request_txn, retry=_retry)
-            return ret.get('succeeded', False)\
-                or ret.get('responses', [{}])[0].get('response_txn', {}).get('succeeded', False)
+            # compare2 = {'key': fields['key'], 'target': 'CREATE', 'create_revision': '0'}
+            # request_txn = {'request_txn': {'compare': [compare2], 'success': [request_put]}}
+            # ret = self._run_and_handle_exceptions(self._client.txn, compare1, request_put, request_txn, retry=_retry)
+            # return ret.get('succeeded', False)\
+                    #    or ret.get('responses', [{}])[0].get('response_txn', {}).get('succeeded', False)
         return bool(self._lease)
 
     @catch_etcd_errors
     def initialize(self, create_new: bool = True, sysid: str = ""):
+        self.cobs.initialize(self.initialize_path)
         return self.retry(self._client.put, self.initialize_path, sysid, create_revision='0' if create_new else None)
 
     @catch_etcd_errors
     def _delete_leader(self, leader: Leader) -> bool:
-        fields = build_range_request(self.leader_path)
-        compare = {'key': fields['key'], 'target': 'VALUE', 'value': base64_encode(self._name)}
-        return bool(self._client.txn(compare, {'request_delete_range': fields}))
+        return bool(self.lockness.release_lock())
+        # fields = build_range_request(self.leader_path)
+        # compare = {'key': fields['key'], 'target': 'VALUE', 'value': base64_encode(self._name)}
+        # return bool(self._client.txn(compare, {'request_delete_range': fields}))
 
     @catch_etcd_errors
     def cancel_initialization(self) -> bool:
+        self.cobs.cancel_initialization(self.initialize_path)
         return self.retry(self._client.deleterange, self.initialize_path)
 
     @catch_etcd_errors

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -788,10 +788,14 @@ class Etcd3(AbstractEtcd):
         return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
 
     def _cluster_loader(self, path: str) -> Cluster:
-        nodes = {node['key'][len(path):]: node
-                 for node in self._client.get_cluster(path)
-                 if node['key'].startswith(path)}
-        return self._cluster_from_nodes(nodes)
+        retry = self._retry.copy()
+        # nodes = {node['key'][len(path):]: node
+        #         for node in self._client.get_cluster(path)
+        #         if node['key'].startswith(path)}
+        # return self._cluster_from_nodes(nodes)
+        def _retry(*args: Any, **kwargs: Any) -> Any:
+            return retry(*args, **kwargs)
+        return self._run_and_handle_exceptions(self.cobs.cluster_loader, path, retry=_retry)
 
     def _citus_cluster_loader(self, path: str) -> Dict[int, Cluster]:
         clusters: Dict[int, Dict[str, Dict[str, Any]]] = defaultdict(dict)
@@ -819,7 +823,16 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def touch_member(self, data: Dict[str, Any]) -> bool:
-        return self.cobs.touch_member(data)
+        cluster = self.cluster
+        member = cluster and cluster.get_member(self._name, fallback_to_leader=False)
+
+        logger.info("Touching member %s", self._name)
+
+        if member and member.session == self._lease and deep_compare(data, member.data):
+            return True
+
+        value = json.dumps(data, separators=(',', ':'))
+        return self.cobs.touch_member(self.member_path, value)
 
     @catch_etcd_errors
     def take_leader(self) -> bool:
@@ -834,7 +847,7 @@ class Etcd3(AbstractEtcd):
         logger.info("attempt to acquire leader")
         try:
             # return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
-            return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
+            return self.lockness.acquire_lock(self.leader_path, self._name, self._ttl)
         except LeaseNotFound:
             logger.error('Our lease disappeared from Etcd. Will try to get a new one and retry attempt')
             self._lease = None
@@ -845,7 +858,7 @@ class Etcd3(AbstractEtcd):
             retry.ensure_deadline(1, Etcd3Error('_do_attempt_to_acquire_leader timeout'))
 
             # return _retry(self._client.put, self.leader_path, self._name, self._lease, create_revision='0')
-            return _retry(self.lockness.acquire_lock, self.leader_path, self._name, self._ttl)
+            return self.lockness.acquire_lock(self.leader_path, self._name, self._ttl)
 
     @catch_return_false_exception
     def attempt_to_acquire_leader(self) -> bool:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -699,17 +699,7 @@ class Etcd3(AbstractEtcd):
         enable_keepalive(sock, self.ttl, int(self.loop_wait + self._retry.deadline))
 
     def set_ttl(self, ttl: int) -> Optional[bool]:
-        # self.__do_not_watch = super(Etcd3, self).set_ttl(ttl)
-        # if self.__do_not_watch:
-        #     self._lease = None
-        # return None
-        try:
-            self.cobs.set("ttl", bytes(str(ttl), 'utf-8'))
-            self._ttl = ttl
-            return True
-        except Exception as e:
-            logger.exception('set_ttl failed: ' + str(e))
-            return False
+        return self.cobs.set_ttl(ttl)
 
     def _do_refresh_lease(self, force: bool = False, retry: Optional[Retry] = None) -> bool:
         if not force and self._lease and self._last_lease_refresh + self._loop_wait > time.time():
@@ -829,24 +819,7 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def touch_member(self, data: Dict[str, Any]) -> bool:
-        try:
-            self.refresh_lease()
-        except Etcd3Error:
-            return False
-
-        cluster = self.cluster
-        member = cluster and cluster.get_member(self._name, fallback_to_leader=False)
-
-        if member and member.session == self._lease and deep_compare(data, member.data):
-            return True
-
-        value = json.dumps(data, separators=(',', ':'))
-        try:
-            return bool(self._client.put(self.member_path, value, self._lease))
-        except LeaseNotFound:
-            self._lease = None
-            logger.error('Our lease disappeared from Etcd, can not "touch_member"')
-        return False
+        return self.cobs.touch_member(data)
 
     @catch_etcd_errors
     def take_leader(self) -> bool:
@@ -893,11 +866,11 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def set_failover_value(self, value: str, version: Optional[str] = None) -> bool:
-        return bool(self._client.put(self.failover_path, value, mod_revision=version))
+        return self.cobs.set_failover_value(value, version)
 
     @catch_etcd_errors
     def set_config_value(self, value: str, version: Optional[str] = None) -> bool:
-        return bool(self._client.put(self.config_path, value, mod_revision=version))
+        return self.cobs.set_config_value(value, version)
 
     @catch_etcd_errors
     def _write_leader_optime(self, last_lsn: str) -> bool:
@@ -937,9 +910,8 @@ class Etcd3(AbstractEtcd):
         return bool(self._lease)
 
     @catch_etcd_errors
-    def initialize(self, create_new: bool = True, sysid: str = ""):
-        self.cobs.initialize(self.initialize_path)
-        return self.retry(self._client.put, self.initialize_path, sysid, create_revision='0' if create_new else None)
+    def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
+        return self.cobs.initialize(create_new, sysid)
 
     @catch_etcd_errors
     def _delete_leader(self, leader: Leader) -> bool:
@@ -950,25 +922,23 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def cancel_initialization(self) -> bool:
-        self.cobs.cancel_initialization(self.initialize_path)
-        return self.retry(self._client.deleterange, self.initialize_path)
+        return self.cobs.cancel_initialization()
 
     @catch_etcd_errors
     def delete_cluster(self) -> bool:
-        return self.retry(self._client.deleteprefix, self.client_path(''))
+        return self.cobs.delete_cluster()
 
     @catch_etcd_errors
     def set_history_value(self, value: str) -> bool:
-        return bool(self._client.put(self.history_path, value))
+        return self.cobs.set_history_value(value)
 
     @catch_etcd_errors
     def set_sync_state_value(self, value: str, version: Optional[str] = None) -> Union[str, bool]:
-        return self.retry(self._client.put, self.sync_path, value, mod_revision=version)\
-            .get('header', {}).get('revision', False)
+        return self.cobs.set_sync_state_value(value, version)
 
     @catch_etcd_errors
     def delete_sync_state(self, version: Optional[str] = None) -> bool:
-        return self.retry(self._client.deleterange, self.sync_path, mod_revision=version)
+        return self.cobs.delete_sync_state(version)
 
     def watch(self, leader_version: Optional[str], timeout: float) -> bool:
         if self.__do_not_watch:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -699,10 +699,17 @@ class Etcd3(AbstractEtcd):
         enable_keepalive(sock, self.ttl, int(self.loop_wait + self._retry.deadline))
 
     def set_ttl(self, ttl: int) -> Optional[bool]:
-        self.__do_not_watch = super(Etcd3, self).set_ttl(ttl)
-        if self.__do_not_watch:
-            self._lease = None
-        return None
+        # self.__do_not_watch = super(Etcd3, self).set_ttl(ttl)
+        # if self.__do_not_watch:
+        #     self._lease = None
+        # return None
+        try:
+            self.cobs.set("ttl", bytes(str(ttl), 'utf-8'))
+            self._ttl = ttl
+            return True
+        except Exception as e:
+            logger.exception('set_ttl failed: ' + str(e))
+            return False
 
     def _do_refresh_lease(self, force: bool = False, retry: Optional[Retry] = None) -> bool:
         if not force and self._lease and self._last_lease_refresh + self._loop_wait > time.time():
@@ -843,7 +850,8 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def take_leader(self) -> bool:
-        return self.retry(self._client.put, self.leader_path, self._name, self._lease)
+        # return self.retry(self._client.put, self.leader_path, self._name, self._lease)
+        return self.lockness.acquire_lock(self.leader_path, self._name, self._ttl)
 
     def _do_attempt_to_acquire_leader(self, retry: Retry) -> bool:
         def _retry(*args: Any, **kwargs: Any) -> Any:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -62,7 +62,18 @@ class Etcd3Exception(etcd.EtcdException):
 
 
 class LockNess:
+    """
+    A class to manage distributed locks using the LockNess service.
+
+    This class provides methods to acquire locks and send heartbeats to maintain them.
+    It uses a SyncClient to connect to the LockNess service.
+    """
     def __init__(self, config: Dict[str, Any]) -> None:
+        """
+        Initialize the LockNess client with the given configuration.
+
+        :param config: A dictionary containing configuration parameters.
+        """
         connect_string = config.get('connect_string', 'host.docker.internal')
         logger.info(f"Connecting to LockNess at {connect_string}")
         self.client = SyncClient.connect(connect_string, port=9111,
@@ -71,6 +82,14 @@ class LockNess:
         self._lock_id = None
 
     def acquire_lock(self, target: str, owner: str, ttl: int) -> bool:
+        """
+        Attempt to acquire a lock for a specified target.
+
+        :param target: The target resource to lock.
+        :param owner: The owner of the lock.
+        :param ttl: Time-to-live for the lock in seconds.
+        :return: True if the lock is acquired, False otherwise.
+        """
         logger.info(f"Acquiring lock for {target} with owner {owner} and ttl {ttl}")
         lock_id = self.client.request_lock(targets=[target], owner=owner,
                                            domain="postgres", ttl=ttl)
@@ -96,6 +115,11 @@ class LockNess:
         return False
 
     def heartbeat(self) -> str | None:
+        """
+        Send a heartbeat to maintain the lock.
+
+        :return: The lock ID if the heartbeat is successful, None otherwise.
+        """
         if self._lock_id is None:
             return None
 

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -10,6 +10,7 @@ import time
 import urllib3
 
 from collections import defaultdict
+from lockness import SyncClient, Heartbeats, LockStatus, LockNessTimeoutError
 from enum import IntEnum
 from urllib3.exceptions import ReadTimeoutError, ProtocolError
 from threading import Condition, Lock, Thread
@@ -58,6 +59,27 @@ GRPCcodeToText: Dict[int, str] = {v: k for k, v in GRPCCode.__dict__['_member_ma
 
 class Etcd3Exception(etcd.EtcdException):
     pass
+
+
+class LockNess:
+    def __init__(self, config: Dict[str, Any]) -> None:
+        connect_string = config.get('connect_string', 'localhost:9111')
+        self.client = SyncClient.connect(connect_string, heartbeats=Heartbeats.auto(20))
+
+    def acquire_lock(self, target: str, owner: str) -> bool:
+        lock_id = self.client.request_lock(targets=[target], owner=owner, domain="postgres")
+        states = self.client.stream_lock_states(lock_id)
+
+        lock_state = None
+        while lock_state is None or lock_state.status != LockStatus.Acquired:
+            try:
+                lock_state = states.recv(timeout_ms=1000)
+            except LockNessTimeoutError:
+                print("Waiting for lock...")
+
+            print(f"Lock state: {lock_state=}")
+            if lock_state.status == LockStatus.Released:
+                raise RuntimeError("Lock was released before acquired")
 
 
 class Etcd3ClientError(Etcd3Exception):

--- a/patroni/dcs/lockness.py
+++ b/patroni/dcs/lockness.py
@@ -1,4 +1,7 @@
+import logging
 from lockness import SyncClient, Heartbeats, LockStatus, LockNessTimeoutError
+
+logger = logging.getLogger(__name__)
 from typing import Dict, Any
 
 class LockNess:

--- a/patroni/dcs/lockness.py
+++ b/patroni/dcs/lockness.py
@@ -17,7 +17,6 @@ class LockNess:
 
         :param config: A dictionary containing configuration parameters.
         """
-        logger.info("TTL: ", ttl)
         connect_string = config.get('connect_string', 'host.docker.internal')
         logger.info(f"Connecting to LockNess at {connect_string}")
         self.client = SyncClient.connect(connect_string, port=9111,
@@ -82,3 +81,4 @@ class LockNess:
         if self._lock_id is not None:
             self.client.release_lock(self._lock_id)
             self._lock_id = None
+

--- a/patroni/dcs/lockness.py
+++ b/patroni/dcs/lockness.py
@@ -35,7 +35,7 @@ class LockNess:
         """
         logger.info(f"Acquiring lock for {target} with owner {owner} and ttl {ttl}")
         lock_id = self.client.request_lock(targets=[target], owner=owner,
-                                           domain="postgres", ttl=ttl)
+                                           domain="postgres", ttl_seconds=ttl)
         logger.info(f"LOCK ID: {lock_id}")
         states = self.client.stream_lock_states(lock_id)
 
@@ -79,6 +79,9 @@ class LockNess:
         Release the lock.
         """
         if self._lock_id is not None:
-            self.client.release_lock(self._lock_id)
-            self._lock_id = None
+            try:
+                self.client.release_lock(self._lock_id)
+                self._lock_id = None
+            except Exception as e:
+                logger.exception(f"Error releasing lock: {e}")
 

--- a/patroni/dcs/lockness.py
+++ b/patroni/dcs/lockness.py
@@ -1,0 +1,81 @@
+from lockness import SyncClient, Heartbeats, LockStatus, LockNessTimeoutError
+from typing import Dict, Any
+
+class LockNess:
+    """
+    A class to manage distributed locks using the LockNess service.
+
+    This class provides methods to acquire locks and send heartbeats to maintain them.
+    It uses a SyncClient to connect to the LockNess service.
+    """
+    def __init__(self, config: Dict[str, Any], ttl: float) -> None:
+        """
+        Initialize the LockNess client with the given configuration.
+
+        :param config: A dictionary containing configuration parameters.
+        """
+        logger.info("TTL: ", ttl)
+        connect_string = config.get('connect_string', 'host.docker.internal')
+        logger.info(f"Connecting to LockNess at {connect_string}")
+        self.client = SyncClient.connect(connect_string, port=9111,
+                                         heartbeats=Heartbeats.auto(int(ttl / 3)),
+                                         auth_n=False)
+        self._lock_id = None
+
+    def acquire_lock(self, target: str, owner: str, ttl: int) -> bool:
+        """
+        Attempt to acquire a lock for a specified target.
+
+        :param target: The target resource to lock.
+        :param owner: The owner of the lock.
+        :param ttl: Time-to-live for the lock in seconds.
+        :return: True if the lock is acquired, False otherwise.
+        """
+        logger.info(f"Acquiring lock for {target} with owner {owner} and ttl {ttl}")
+        lock_id = self.client.request_lock(targets=[target], owner=owner,
+                                           domain="postgres", ttl=ttl)
+        logger.info(f"LOCK ID: {lock_id}")
+        states = self.client.stream_lock_states(lock_id)
+
+        self._lock_id = lock_id
+
+        lock_state = None
+        while lock_state is None or lock_state.status != LockStatus.Acquired:
+            try:
+                lock_state = states.recv(timeout_ms=1000)
+                if lock_state is None:
+                    continue
+                if lock_state is not None and lock_state.status == LockStatus.Acquired:
+                    return True
+
+                return False
+            except LockNessTimeoutError:
+                logger.info("Waiting for lock...")
+
+            logger.info(f"Lock state: {lock_state=}")
+
+        return False
+
+    def heartbeat(self) -> str | None:
+        """
+        Send a heartbeat to maintain the lock.
+
+        :return: The lock ID if the heartbeat is successful, None otherwise.
+        """
+        if self._lock_id is None:
+            return None
+
+        try:
+            self.client.send_heartbeat(self._lock_id)
+        except Exception as e:
+            logger.exception(f"Error sending heartbeat: {e}")
+
+        return self._lock_id
+
+    def release_lock(self) -> None:
+        """
+        Release the lock.
+        """
+        if self._lock_id is not None:
+            self.client.release_lock(self._lock_id)
+            self._lock_id = None

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -26,6 +26,7 @@ etcd:
   #Provide host to do the initial discovery of the cluster topology:
 
   host: 127.0.0.1:2379
+  port: 9111
 
   #Or use "hosts" to provide multiple endpoints
   #Could be a comma separated string:

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -24,7 +24,9 @@ restapi:
 
 etcd:
   #Provide host to do the initial discovery of the cluster topology:
+
   host: 127.0.0.1:2379
+
   #Or use "hosts" to provide multiple endpoints
   #Could be a comma separated string:
   #hosts: host1:port1,host2:port2

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -22,7 +22,10 @@ restapi:
 #  database: citus
 #  group: 1  # worker
 
+lockness_port: 9112
+
 etcd:
+  lockness_port: 9112
   #Provide host to do the initial discovery of the cluster topology:
   host: 127.0.0.1:2379
   #Or use "hosts" to provide multiple endpoints

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -22,7 +22,10 @@ restapi:
 #  database: citus
 #  group: 1  # worker
 
+lockness_port: 9113
+
 etcd:
+  lockness_port: 9113
   #Provide host to do the initial discovery of the cluster topology:
   host: 127.0.0.1:2379
   #Or use "hosts" to provide multiple endpoints

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -22,6 +22,9 @@
   "pythonVersion": "3.11",
   "pythonPlatform": "All",
 
-  "typeCheckingMode": "strict"
+  "typeCheckingMode": "strict",
 
+  "executionEnvironments": [
+      {"root": "src"}
+  ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pysyncobj>=0.3.8
 cryptography>=1.4
 psutil>=2.0.0
 ydiff>=1.2.0
+cobs_client @ https://binaries.ddbuild.io/dd-source/python/cobs_client-0.0.42842433-py3-none-any.whl
+lockness @ https://binaries.ddbuild.io/dd-source/python/lockness-0.0.55294957-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ pysyncobj>=0.3.8
 cryptography>=1.4
 psutil>=2.0.0
 ydiff>=1.2.0
-cobs_client @ https://binaries.ddbuild.io/dd-source/python/cobs_client-0.0.42842433-py3-none-any.whl
+cobs_client @ https://binaries.ddbuild.io/dd-source/python/cobs_client-0.0.52871086-py3-none-any.whl
 lockness @ https://binaries.ddbuild.io/dd-source/python/lockness-0.0.55294957-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ AUTHOR_EMAIL = 'akukushkin@microsoft.com, polina.bungina@zalando.de'
 KEYWORDS = 'etcd governor patroni postgresql postgres ha haproxy confd' +\
     ' zookeeper exhibitor consul streaming replication kubernetes k8s'
 
-EXTRAS_REQUIRE = {'aws': ['boto3'], 'etcd': ['python-etcd'], 'etcd3': ['python-etcd'],
+EXTRAS_REQUIRE = {'aws': ['boto3'], 'etcd': ['python-etcd'], 'etcd3': ['python-etcd', 'lockness'],
                   'consul': ['python-consul'], 'exhibitor': ['kazoo'], 'zookeeper': ['kazoo'],
                   'kubernetes': [], 'raft': ['pysyncobj', 'cryptography']}
 


### PR DESCRIPTION
To test, first build the image with
```
$ docker build -t patroni .
```

Then, get local versions of LockNess and COBS running in separate terminals:
```
$ cd ~/dd/dd-source
$ OBSERVABILITY=disabled bzl run //domains/lockness/apps/lockness-rs:lockness-rs -- --backend=inmemory --port 9111 --log-level error
```
```
$ cd ~/dd/dd-source
$ POD_NAMESPACE="cobs" \
DD_DATACENTER="us1.ddbuild.io"  \
COBS_CONFIG_PATH="$DATADOG_ROOT/dd-source/domains/msp/apps/cobs/etc/local.toml" \
  bzl run //domains/msp/apps/cobs:dev
```

Finally, run the docker-compose file for Patroni with
```
docker-compose up
```